### PR TITLE
Add `camel2UnderlineComponentName` to support react-toolbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "expect": "^1.13.4",
     "material-ui": "^0.15.4",
     "mocha": "^2.3.4",
-    "pre-commit": "~1.1.2"
+    "pre-commit": "~1.1.2",
+    "react-toolbox": "^1.2.5"
   },
   "babel": {
     "presets": [

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -1,7 +1,7 @@
 import { join } from 'path';
 
 export default class Plugin {
-  constructor(libraryName, libraryDirectory, style, camel2DashComponentName, types) {
+  constructor(libraryName, libraryDirectory, style, camel2DashComponentName, camel2UnderlineComponentName, types) {
     this.specified = null;
     this.libraryObjs = null;
     this.selectedMethods = null;
@@ -12,6 +12,7 @@ export default class Plugin {
     this.camel2DashComponentName = typeof camel2DashComponentName === 'undefined'
       ? true
       : camel2DashComponentName;
+    this.camel2UnderlineComponentName = camel2UnderlineComponentName;
     this.style = style || false;
     this.types = types;
   }
@@ -20,9 +21,11 @@ export default class Plugin {
     if (!this.selectedMethods[methodName]) {
       const libraryDirectory = this.libraryDirectory;
       const style = this.style;
-      const transformedMethodName = this.camel2DashComponentName
-        ? camel2Dash(methodName)
-        : methodName;
+      const transformedMethodName = this.camel2UnderlineComponentName
+        ? camel2Underline(methodName)
+        : this.camel2DashComponentName
+          ? camel2Dash(methodName)
+          : methodName;
       const path = winPath(join(this.libraryName, libraryDirectory, transformedMethodName));
       this.selectedMethods[methodName] = file.addImport(path, 'default');
       if (style === true) {
@@ -166,6 +169,13 @@ function camel2Dash(_str) {
   const str = _str[0].toLowerCase() + _str.substr(1);
   return str.replace(/([A-Z])/g, function camel2DashReplace($1) {
     return '-' + $1.toLowerCase();
+  });
+}
+
+function camel2Underline(_str) {
+  const str = _str[0].toLowerCase() + _str.substr(1);
+  return str.replace(/([A-Z])/g, function ($1) {
+    return '_' + $1.toLowerCase();
   });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,15 +21,15 @@ export default function ({ types }) {
     // Init plugin instances once.
     if (!plugins) {
       if (Array.isArray(opts)) {
-        plugins = opts.map(({ libraryName, libraryDirectory, style, camel2DashComponentName }) => {
+        plugins = opts.map(({ libraryName, libraryDirectory, style, camel2DashComponentName, camel2UnderlineComponentName }) => {
           assert(libraryName, 'libraryName should be provided');
-          return new Plugin(libraryName, libraryDirectory, style, camel2DashComponentName, types);
+          return new Plugin(libraryName, libraryDirectory, style, camel2DashComponentName, camel2UnderlineComponentName, types);
         });
       } else {
         opts = opts || {};
         assert(opts.libraryName, 'libraryName should be provided');
         plugins = [
-          new Plugin(opts.libraryName, opts.libraryDirectory, opts.style, opts.camel2DashComponentName, types)
+          new Plugin(opts.libraryName, opts.libraryDirectory, opts.style, opts.camel2DashComponentName, opts.camel2UnderlineComponentName, types),
         ];
       }
     }
@@ -54,7 +54,7 @@ export default function ({ types }) {
   };
 
   for (const method of methods) {
-    ret.visitor[method] = function() {
+    ret.visitor[method] = function () {
       applyInstance(method, arguments, ret.visitor);
     };
   }

--- a/test/fixtures/react-toolbox/actual.js
+++ b/test/fixtures/react-toolbox/actual.js
@@ -1,0 +1,3 @@
+import { AppBar } from 'react-toolbox';
+
+AppBar('xxx');

--- a/test/fixtures/react-toolbox/expected.js
+++ b/test/fixtures/react-toolbox/expected.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var _app_bar = require('react-toolbox/lib/app_bar');
+
+var _app_bar2 = _interopRequireDefault(_app_bar);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _app_bar2.default)('xxx');

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -36,6 +36,12 @@ describe('index', () => {
             { libraryName: 'material-ui', libraryDirectory: '', camel2DashComponentName: false },
           ]
         ];
+      } else if (caseName === 'react-toolbox') {
+        pluginWithOpts = [
+          plugin, [
+            { libraryName: 'react-toolbox', camel2UnderlineComponentName: true },
+          ]
+        ];
       } else if (caseName === 'multiple-libraries') {
         pluginWithOpts = [
           plugin, [


### PR DESCRIPTION
See: http://react-toolbox.com/#/components/app_bar

Its component name is `AppBar`, but path is `lib/app_bar`.
Currently, we only have option to convert it to `lib/app-bar`.