### PR TITLE
delete incorrect config for antd-mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ For Example:
     "style": true
   },
   {
-    "libraryName": "antd-mobile",
-    "libraryDirectory": "component",
+    "libraryName": "antd-mobile"
   },
 ]
 ```


### PR DESCRIPTION
删除 `antd-mobile` 错误用法，防止误导用户。