### PR TITLE
feat: support opts.fileName

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-import",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Component modular import plugin for babel.",
   "repository": {
     "type": "git",

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -21,6 +21,7 @@ export default class Plugin {
     style,
     camel2DashComponentName,
     camel2UnderlineComponentName,
+    fileName,
     types
   ) {
     this.specified = null;
@@ -35,6 +36,7 @@ export default class Plugin {
       : camel2DashComponentName;
     this.camel2UnderlineComponentName = camel2UnderlineComponentName;
     this.style = style || false;
+    this.fileName = fileName || '';
     this.types = types;
   }
 
@@ -47,7 +49,9 @@ export default class Plugin {
         : this.camel2DashComponentName
           ? camel2Dash(methodName)
           : methodName;
-      const path = winPath(join(this.libraryName, libraryDirectory, transformedMethodName));
+      const path = winPath(
+        join(this.libraryName, libraryDirectory, transformedMethodName, this.fileName)
+      );
       this.selectedMethods[methodName] = file.addImport(path, 'default');
       if (style === true) {
         file.addImport(`${path}/style`, 'style');

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export default function ({ types }) {
           style,
           camel2DashComponentName,
           camel2UnderlineComponentName,
+          fileName,
         }) => {
           assert(libraryName, 'libraryName should be provided');
           return new Plugin(
@@ -35,6 +36,7 @@ export default function ({ types }) {
             style,
             camel2DashComponentName,
             camel2UnderlineComponentName,
+            fileName,
             types
           );
         });
@@ -47,6 +49,7 @@ export default function ({ types }) {
             opts.style,
             opts.camel2DashComponentName,
             opts.camel2UnderlineComponentName,
+            opts.fileName,
             types
           ),
         ];

--- a/test/fixtures/file-name/actual.js
+++ b/test/fixtures/file-name/actual.js
@@ -1,0 +1,5 @@
+import { Select } from 'antd-mobile-fake-2.0';
+
+if (Select) {}
+
+console.log(Select);

--- a/test/fixtures/file-name/expected.js
+++ b/test/fixtures/file-name/expected.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var _index = require('antd-mobile-fake-2.0/lib/select/index.native');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+if (_index2.default) {}
+
+console.log(_index2.default);

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -49,6 +49,14 @@ describe('index', () => {
             { libraryName: 'antd-mobile' },
           ]
         ];
+      } else if (caseName === 'file-name') {
+        pluginWithOpts = [
+          plugin,
+          {
+            libraryName: 'antd-mobile-fake-2.0',
+            fileName: 'index.native',
+          },
+        ];
       } else {
         pluginWithOpts = [
           plugin, { libraryName: 'antd' }


### PR DESCRIPTION
close https://github.com/ant-design/babel-plugin-import/issues/116

`antd-mobile@2.0` will change file extension as below https://github.com/ant-design/ant-design-mobile/issues/1235 :

- `.native.js`: react native component
- `.js`: web component

so no need to rely on `webpack.resolve` config, which cause trouble in server side render.

`antd-mobile@2.0` will suggest users to use babel-plugin-import handle both web component&style import and react-native component import.