### PR TITLE
treat @babel/helper-module-imports as peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "package.json",
     "README.md"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@babel/helper-module-imports": "^7.0.0-beta.34"
   }
 }


### PR DESCRIPTION
treat `@babel/helper-module-imports` as `peerDependencies`