### PR TITLE
Fix multiple imports

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -44,8 +44,7 @@ export default class Plugin {
   }
 
   importMethod(methodName, file) {
-    // disable selectedMethods cache, it don't work in babel7
-    if (true /*!this.selectedMethods[methodName]*/) { // eslint-disable-line
+    if (!this.selectedMethods[methodName]) {
       const libraryDirectory = this.libraryDirectory;
       const style = this.style;
       const transformedMethodName = this.camel2UnderlineComponentName  // eslint-disable-line
@@ -63,7 +62,7 @@ export default class Plugin {
         addSideEffect(file.path, `${path}/style/css`);
       }
     }
-    return this.selectedMethods[methodName];
+    return Object.assign({}, this.selectedMethods[methodName]);
   }
 
   buildExpressionHandler(node, props, path, state) {


### PR DESCRIPTION
原来在 babel 7 里有问题是因为[这里](https://github.com/babel/babel/blob/a07f96ce3f28ed053c7e5e061dae3627ff451bc5/packages/babel-helper-module-transforms/src/rewrite-live-references.js#L169) 有判断会跳过相同的节点，clone 一次就可以绕过这个问题。