### PR TITLE
Add more backticks to fix example code render bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ For Example:
 If option style is a `Function`, `babel-plugin-import` will auto import the file which filepath equal to the function return value. This is useful for the components library developers.
 
 e.g. 
-- `["import", { "libraryName": "antd", "style": (name) => `${name}/style/2x` }]`: import js and css modularly & css file path is `ComponentName/style/2x`
+- ``["import", { "libraryName": "antd", "style": (name) => `${name}/style/2x` }]``: import js and css modularly & css file path is `ComponentName/style/2x`
 
 ### Note
 


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/743976/39213531-d5511562-47df-11e8-9cc9-639ab4bbee74.png)


The backticks were triggering the end of the code block. Needed to add more backticks :)
Reference: https://github.com/github/markup/issues/363