### PR TITLE
fix bug in ReturnStatement method

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -43,6 +43,12 @@ export default class Plugin {
     this.types = types;
   }
 
+  isInGlobalScope(path, name) {
+    const parentPath = path.findParent((_path) =>
+    _path.scope.hasOwnBinding(this.specified[name]));
+    return !!parentPath && parentPath.isProgram();
+  }
+
   importMethod(methodName, file) {
     if (!this.selectedMethods[methodName]) {
       const libraryDirectory = this.libraryDirectory;
@@ -203,7 +209,9 @@ export default class Plugin {
     const types = this.types;
     const file = (path && path.hub && path.hub.file) || (state && state.file);
     const { node } = path;
-    if (node.argument && types.isIdentifier(node.argument) && this.specified[node.argument.name]) {
+
+    if (node.argument && types.isIdentifier(node.argument) && this.specified[node.argument.name] &&
+    this.isInGlobalScope(path, node.argument.name)) {
       node.argument = this.importMethod(node.argument.name, file);
     }
   }

--- a/test/fixtures/return/actual.js
+++ b/test/fixtures/return/actual.js
@@ -3,3 +3,19 @@ import { toast } from 'antd';
 function a() {
   return toast;
 }
+
+function b(toast) {
+  return toast;
+}
+
+function c() {
+  var toast = 'toast';
+  return toast;
+}
+
+function d() {
+  var toast = 'toast';
+  return function () {
+    return toast;
+  };
+}

--- a/test/fixtures/return/expected.js
+++ b/test/fixtures/return/expected.js
@@ -7,3 +7,19 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function a() {
   return _toast2.default;
 }
+
+function b(toast) {
+  return toast;
+}
+
+function c() {
+  var toast = 'toast';
+  return toast;
+}
+
+function d() {
+  var toast = 'toast';
+  return function () {
+    return toast;
+  };
+}


### PR DESCRIPTION
如果项目没遵守 ESLint 的 no-shadow 规则，在 function 中声明了与 import 进来的模块同名的变量，并 return 了这个变量。这时就会出现，这个变量被替换的 bug