### PR TITLE
Add Option to Keep Named Imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ For Example:
 ]
 ```
 
-### style
+#### style
 
 - `["import", { "libraryName": "antd" }]`: import js modularly
 - `["import", { "libraryName": "antd", "style": true }]`: import js and css modularly (LESS/Sass source files)
@@ -159,7 +159,7 @@ e.g.
 ]
 ```
 
-### customName
+#### customName
 
 We can use `customName` to customize import file path.
 
@@ -203,6 +203,10 @@ import { TimePicker } from "antd"
 ↓ ↓ ↓ ↓ ↓ ↓
 var _button = require('antd/lib/custom-time-picker');
 ```
+
+#### transformToDefaultImport
+
+Set this option to `false` if your module does not have a `default` export.
 
 ### Note
 

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { addSideEffect, addDefault } from '@babel/helper-module-imports';
+import { addSideEffect, addDefault, addNamed } from '@babel/helper-module-imports';
 
 function camel2Dash(_str) {
   const str = _str[0].toLowerCase() + _str.substr(1);
@@ -24,6 +24,7 @@ export default class Plugin {
     camel2UnderlineComponentName,
     fileName,
     customName,
+    transformToDefaultImport,
     types
   ) {
     this.specified = null;
@@ -40,6 +41,9 @@ export default class Plugin {
     this.style = style || false;
     this.fileName = fileName || '';
     this.customName = customName;
+    this.transformToDefaultImport = typeof transformToDefaultImport === 'undefined'
+      ? true
+      : transformToDefaultImport;
     this.types = types;
   }
 
@@ -61,7 +65,9 @@ export default class Plugin {
       const path = winPath(
         this.customName ? this.customName(transformedMethodName) : join(this.libraryName, libraryDirectory, transformedMethodName, this.fileName) // eslint-disable-line
       );
-      this.selectedMethods[methodName] = addDefault(file.path, path, { nameHint: methodName });
+      this.selectedMethods[methodName] = this.transformToDefaultImport
+        ? addDefault(file.path, path, { nameHint: methodName })
+        : addNamed(file.path, methodName, path);
       if (style === true) {
         addSideEffect(file.path, `${path}/style`);
       } else if (style === 'css') {

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ export default function ({ types }) {
             camel2UnderlineComponentName,
             fileName,
             customName,
+            transformToDefaultImport,
           }) => {
             assert(libraryName, 'libraryName should be provided');
             return new Plugin(
@@ -40,6 +41,7 @@ export default function ({ types }) {
               camel2UnderlineComponentName,
               fileName,
               customName,
+              transformToDefaultImport,
               types
             );
           });
@@ -54,6 +56,7 @@ export default function ({ types }) {
               opts.camel2UnderlineComponentName,
               opts.fileName,
               opts.customName,
+              opts.transformToDefaultImport,
               types
             ),
           ];

--- a/test/fixtures/keep-named-import/actual.js
+++ b/test/fixtures/keep-named-import/actual.js
@@ -1,0 +1,4 @@
+import { start, end } from 'stream';
+
+start();
+end();

--- a/test/fixtures/keep-named-import/expected.js
+++ b/test/fixtures/keep-named-import/expected.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var _end2 = require("stream/lib/end");
+
+var _start2 = require("stream/lib/start");
+
+(0, _start2.start)();
+(0, _end2.end)();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,6 +33,10 @@ describe('index', () => {
         pluginWithOpts = [
           plugin, { libraryName: 'material-ui', libraryDirectory: '', camel2DashComponentName: false },
         ];
+      } else if (caseName === 'keep-named-import') {
+        pluginWithOpts = [
+          plugin, { libraryName: 'stream', transformToDefaultImport: false },
+        ];
       } else if (caseName === 'react-toolbox') {
         pluginWithOpts = [
           plugin, { libraryName: 'react-toolbox', camel2UnderlineComponentName: true },


### PR DESCRIPTION
Hey guys,

I've added a plugin option that lets you keep the named import.

```js
import { Bar } from 'foo';
```

is then equivalent to

```js
import { Bar } from 'foo/lib/bar';
```

instead of

```js
import Bar from 'foo/lib/bar';
```

for example. I think there is no way around this if you're working with a project that does not have default exports.

P.S. I also edited the README. The fields of the options object (####) should be under the Options heading (###).