### PR TITLE
fix buildDeclaratorHandler

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -108,7 +108,7 @@ export default class Plugin {
     if (pluginState.specified[node[prop].name] &&
       path.scope.hasBinding(node[prop].name) &&
       path.scope.getBinding(node[prop].name).path.type === 'ImportSpecifier') {
-      node[prop] = this.importMethod(node[prop].name, file, pluginState);  // eslint-disable-line
+      node[prop] = this.importMethod(pluginState.specified[node[prop].name], file, pluginState);  // eslint-disable-line
     }
   }
 


### PR DESCRIPTION
```
import { Button as Btn } from 'antd';

const a = Btn
```

When I use this way，it will be converted to

```
import _btn from 'antd/lib/btn';

const a = _btn
```

Instead of

```
import _button from 'antd/lib/button';

const a = _button
```

I think method `/src/Plugin/buildDeclaratorHandler` should use `pluginState.specified[node[prop].name]`  instead of `node[prop].name`.  Thank you.