### PR TITLE
rm pkg babel config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 lib
 *.log
 *.log.*
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -37,11 +37,6 @@
     "react-toolbox": "^1.2.5",
     "umi-tools": "^0.1.4"
   },
-  "babel": {
-    "presets": [
-      "umi"
-    ]
-  },
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
if not remove the `pkg.babel`, will cause build bugs in `umi-tools ^0.4.0`.

![image](https://user-images.githubusercontent.com/13595509/58101900-f9941d80-7c12-11e9-8ebd-8ca847bd5d7e.png)
