### PR TITLE
fix: local scope bug

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -184,8 +184,16 @@ export default class Plugin {
     if (pluginState.libraryObjs[node.object.name]) {
       // antd.Button -> _Button
       path.replaceWith(this.importMethod(node.property.name, file, pluginState));
-    } else if (pluginState.specified[node.object.name]) {
-      node.object = this.importMethod(pluginState.specified[node.object.name], file, pluginState);
+    } else if (pluginState.specified[node.object.name] && path.scope.hasBinding(node.object.name)) {
+      const scope = path.scope.getBinding(node.object.name).scope;
+      // global variable in file scope
+      if (scope.path.parent.type === 'File') {
+        node.object = this.importMethod(
+          pluginState.specified[node.object.name],
+          file,
+          pluginState
+        );
+      }
     }
   }
 

--- a/test/fixtures/variable-scope/actual.js
+++ b/test/fixtures/variable-scope/actual.js
@@ -2,6 +2,8 @@ import { message } from 'antd';
 
 message('xxx');
 
+message.error('error');
+
 const testIf = (message) => {
   if (message) return message
 }
@@ -15,6 +17,25 @@ const testExpression2 = () => message + 'test'
 
 const testNestFunction = message => a => message
 const testNestFunction2 = () => a => message
+const testFunction = message => {
+  message.error('error');
+  return message.test;
+}
+const testFunction1 = () => message.error('error');
+const testFunction2 = message => message.error('error');
+const testFunction3 = message => {
+  if(message) {
+    message = message.test.message;
+    for (let i = 0; i < 10; i++) {
+      const message = i;
+      if (message > 4) {
+        return message;
+      }
+    }
+  }
+  message = null;
+  return message;
+}
 
 function App() {
   const message = 'xxx';

--- a/test/fixtures/variable-scope/expected.js
+++ b/test/fixtures/variable-scope/expected.js
@@ -2,18 +2,20 @@
 
 var _react = _interopRequireDefault(require("react"));
 
-var _message2 = _interopRequireDefault(require("antd/lib/message"));
+var _message3 = _interopRequireDefault(require("antd/lib/message"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-(0, _message2.default)('xxx');
+(0, _message3.default)('xxx');
+
+_message3.default.error('error');
 
 var testIf = function testIf(message) {
   if (message) return message;
 };
 
 var testIf2 = function testIf2() {
-  if (_message2.default) return _message2.default;
+  if (_message3.default) return _message3.default;
 };
 
 var testExpression = function testExpression(message) {
@@ -21,7 +23,7 @@ var testExpression = function testExpression(message) {
 };
 
 var testExpression2 = function testExpression2() {
-  return _message2.default + 'test';
+  return _message3.default + 'test';
 };
 
 var testNestFunction = function testNestFunction(message) {
@@ -32,8 +34,38 @@ var testNestFunction = function testNestFunction(message) {
 
 var testNestFunction2 = function testNestFunction2() {
   return function (a) {
-    return _message2.default;
+    return _message3.default;
   };
+};
+
+var testFunction = function testFunction(message) {
+  message.error('error');
+  return message.test;
+};
+
+var testFunction1 = function testFunction1() {
+  return _message3.default.error('error');
+};
+
+var testFunction2 = function testFunction2(message) {
+  return message.error('error');
+};
+
+var testFunction3 = function testFunction3(message) {
+  if (message) {
+    message = message.test.message;
+
+    for (var i = 0; i < 10; i++) {
+      var _message2 = i;
+
+      if (_message2 > 4) {
+        return _message2;
+      }
+    }
+  }
+
+  message = null;
+  return message;
 };
 
 function App() {


### PR DESCRIPTION
I have some code just like follow:
```javascript
import React from 'react';
import { Button, message } from 'antd';
import './App.css';

const onAlert = () => {
  message.success(genMsg({ c: 'fffff' }));
};

const genMsg = message => `this is ${message.c}`;

function App() {
  return (
    <div className="App">
      <Button onClick={onAlert}>antd</Button>
    </div>
  );
}

export default App;
```

when I use `babel-plugin-import` to convert my code, it generate some unexpected code:
```javascript
"use strict";
__webpack_require__.r(__webpack_exports__);
/* harmony import */ var antd_es_button_style_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! antd/es/button/style/css */ "./node_modules/antd/es/button/style/css.js");
/* harmony import */ var antd_es_button__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! antd/es/button */ "./node_modules/antd/es/button/index.js");
/* harmony import */ var antd_es_message_style_css__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! antd/es/message/style/css */ "./node_modules/antd/es/message/style/css.js");
/* harmony import */ var antd_es_message__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! antd/es/message */ "./node_modules/antd/es/message/index.js");
/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! react */ "./node_modules/react/index.js");
/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_4__);
/* harmony import */ var _App_css__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ./App.css */ "./src/App.css");
/* harmony import */ var _App_css__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(_App_css__WEBPACK_IMPORTED_MODULE_5__);




var _jsxFileName = "/Users/zhengqc/project/github/my-app/src/App.js";



const onAlert = () => {
  antd_es_message__WEBPACK_IMPORTED_MODULE_3__["default"].success(genMsg({
    c: 'fffff'
  }));
};

const genMsg = message => "this is ".concat(antd_es_message__WEBPACK_IMPORTED_MODULE_3__["default"].c);

function App() {
  return react__WEBPACK_IMPORTED_MODULE_4___default.a.createElement("div", {
    className: "App",
    __source: {
      fileName: _jsxFileName,
      lineNumber: 13
    },
    __self: this
  }, react__WEBPACK_IMPORTED_MODULE_4___default.a.createElement(antd_es_button__WEBPACK_IMPORTED_MODULE_1__["default"], {
    onClick: onAlert,
    __source: {
      fileName: _jsxFileName,
      lineNumber: 14
    },
    __self: this
  }, "antd"));
}

/* harmony default export */ __webpack_exports__["default"] = (App);
```
as u see, the follow codes is unexpected:
```javascript
const genMsg = message => "this is ".concat(antd_es_message__WEBPACK_IMPORTED_MODULE_3__["default"].c);
```
the right result is:
```javascript
const genMsg = message => "this is ".concat(message.c);
```
because the `message` is a local scope variable, it shouldn't to be convert. This case occured in my online project that is very hoary after I added `babel-plugin-import` to optimize it. I try to fix it and add some test cases that is passed after I debug the source codes, . Pls check.

How to reproduce it? Pls click the follow link to download demo for it.
[my-app.zip](https://github.com/ant-design/babel-plugin-import/files/3638373/my-app.zip)
