### PR TITLE
feat: support matching relative path

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,3 @@
+export function isRelativePath(nodePath) {
+  return /^\.?\.\//.test(nodePath);
+}

--- a/test/fixtures/library-name-function/actual.js
+++ b/test/fixtures/library-name-function/actual.js
@@ -1,0 +1,20 @@
+import { Button } from 'antd';
+import { Select } from 'antd/index';
+import { Tab } from './components/index';
+import { Icon } from './components';
+
+if (Button) {
+  console.log('Button');
+}
+
+if (Select) {
+  console.log('Select');
+}
+
+if (Tab) {
+  console.log('Tab');
+}
+
+if (Icon) {
+  console.log('Icon');
+}

--- a/test/fixtures/library-name-function/expected.js
+++ b/test/fixtures/library-name-function/expected.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var _icon = _interopRequireDefault(require("@library-name-function/components/icon"));
+
+var _tab = _interopRequireDefault(require("@library-name-function/components/tab"));
+
+var _select = _interopRequireDefault(require("antd/lib/select"));
+
+var _button = _interopRequireDefault(require("antd/lib/button"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+if (_button.default) {
+  console.log('Button');
+}
+
+if (_select.default) {
+  console.log('Select');
+}
+
+if (_tab.default) {
+  console.log('Tab');
+}
+
+if (_icon.default) {
+  console.log('Icon');
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,5 @@
 import { transformFileSync, transform } from "@babel/core";
-import { join } from 'path';
+import { join, parse, resolve } from 'path';
 import { readdirSync, readFileSync } from 'fs';
 import plugin from '../src/index';
 
@@ -150,6 +150,26 @@ describe('index', () => {
           return transformFileSync(actualFile, {
             plugins: [[plugin, { libraryName: 'antd' }]],
             babelrc: false,
+          }).code;
+        } else if (caseName === 'library-name-function') {
+          return transformFileSync(actualFile, {
+            plugins: [
+              [
+                plugin, {
+                  libraryName: ({ sourceValue }) => sourceValue === 'antd' || sourceValue === 'antd/index',
+                  customName: (name) => `antd/lib/${name}`
+                }
+              ],
+              [
+                plugin, {
+                  libraryName: ({getLibraryFileIfRelative}) => {
+                    return /[\//]test[\//]fixtures[\//]library-name-function[\//]components/.test(getLibraryFileIfRelative());
+                  },
+                  customName: (name) => `@library-name-function/components/${name}`
+                },
+                '@library-name-function/components'
+              ]
+            ]
           }).code;
         } else {
           return transformFileSync(actualFile, {


### PR DESCRIPTION
webpack alias 配置:
```'@common/components': 'src/common/components'```

因为项目中有各种各样的引用方式，引用到```src/common/components/index.js```导致无法按需引入。
```
import { Icon } from '../';
import { Icon } from '../index';
import { Icon } from '../components';
import { Icon } from '@common/components';
import { Icon } from '@common/components/index';
```

希望支持本地路径，这样上方的引用路径，都能通过插件转成如下形式：
```
import Icon from '@common/components/Icon';
```