### PR TITLE
fix: newExpression arguments not be traverse issue

### DIFF
--- a/test/fixtures/as-arguments-identifier/actual.js
+++ b/test/fixtures/as-arguments-identifier/actual.js
@@ -1,2 +1,3 @@
 import { Modal } from 'antd';
 const _Modal = bind()(Modal);
+const _newModal = new AnyClass(Modal);

--- a/test/fixtures/as-arguments-identifier/expected.js
+++ b/test/fixtures/as-arguments-identifier/expected.js
@@ -5,3 +5,5 @@ var _modal = _interopRequireDefault(require("antd/lib/modal"));
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var _Modal = bind()(_modal.default);
+
+var _newModal = new AnyClass(_modal.default);


### PR DESCRIPTION
# 修复 newExpression arguments 并没有 被转换的问题

- bug现状说明：
```js
// 源码
import { Button } from 'antd';
console.log(Button);
new A(Button);

// 转译后代码
var _button = _interopRequireDefault(require("antd/lib/button"));
function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
console.log(_button.default);
new A(Button); // FIXME: 由于 Button 并不会被处理，导致运行时报错：Uncaught ReferenceError: Button is not defined
```

- 原因分析
  - 在 plugin.js 源码文件中，由于 arguments 是「数组」，而 buildExpressionHandler  并没有处理「数组」这种情况
导致：NewExpression 给 buildExpressionHandler 传递了 arguments 但却没有起到任何作用

- 解决方案
  - 修正对 newExpression 下的 arguments 的转换